### PR TITLE
Fix/add substring method in jwt utils#47

### DIFF
--- a/src/main/java/com/strcat/service/UserService.java
+++ b/src/main/java/com/strcat/service/UserService.java
@@ -15,7 +15,7 @@ public class UserService {
     private final JwtUtils jwtUtils;
 
     public User getUser(String token) {
-        Long userId = Long.parseLong(jwtUtils.parseUserId(token.substring(7)));
+        Long userId = Long.parseLong(jwtUtils.parseUserId(jwtUtils.removeBearerString(token)));
         Optional<User> user = userRepository.findById(userId);
 
         if (user.isEmpty()) {
@@ -25,7 +25,7 @@ public class UserService {
     }
 
     public boolean isLogin(String token) {
-        String tokenCode = token.substring(7);
+        String tokenCode = jwtUtils.removeBearerString(token);
         if (!jwtUtils.isValidateToken(tokenCode)) {
             return false;
         }

--- a/src/main/java/com/strcat/util/JwtUtils.java
+++ b/src/main/java/com/strcat/util/JwtUtils.java
@@ -16,6 +16,13 @@ public class JwtUtils {
     private final SecretKey secretKey;
     private final Long VALID_MINUTES = 300L; // TODO: 시간 변경 300 -> 60
 
+    public String removeBearerString(String token) {
+        if (token == null || token.isBlank()) {
+            return "";
+        }
+        return token.substring(7);
+    }
+
     public JwtUtils(@Value("${jwt.secret}") String secretKey) {
         byte[] encoded = Base64.getEncoder().encode(secretKey.getBytes());
 
@@ -25,7 +32,7 @@ public class JwtUtils {
     public String exportToken(HttpServletRequest request) {
         String rawToken = request.getHeader("Authorization");
 
-        if (rawToken == null) {
+        if (rawToken == null || rawToken.isBlank()) {
             return "";
         }
 
@@ -33,7 +40,7 @@ public class JwtUtils {
         String token = "";
 
         if (bearer.equals("Bearer")) {
-            token = rawToken.substring(7);
+            token = removeBearerString(rawToken);
         }
         return token;
     }

--- a/src/main/java/com/strcat/util/JwtUtils.java
+++ b/src/main/java/com/strcat/util/JwtUtils.java
@@ -17,7 +17,9 @@ public class JwtUtils {
     private final Long VALID_MINUTES = 300L; // TODO: 시간 변경 300 -> 60
 
     public String removeBearerString(String token) {
-        if (token == null || token.isBlank()) {
+        if (token == null
+                || token.isBlank()
+                || token.length() < 7) {
             return "";
         }
         return token.substring(7);
@@ -32,14 +34,16 @@ public class JwtUtils {
     public String exportToken(HttpServletRequest request) {
         String rawToken = request.getHeader("Authorization");
 
-        if (rawToken == null || rawToken.isBlank()) {
+        if (rawToken == null
+                || rawToken.isBlank()
+                || rawToken.length() < 6) {
             return "";
         }
 
-        String bearer = rawToken.substring(0, 6);
+        String prefix = rawToken.substring(0, 6);
         String token = "";
 
-        if (bearer.equals("Bearer")) {
+        if (prefix.equals("Bearer")) {
             token = removeBearerString(rawToken);
         }
         return token;


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Issue 생성 전 체크리스트(생성한 사람이 꼭 모두 체크해주세요!!)
- [ ] 이슈 이름은 다른 사람도 이해할 수 있나요?
- [ ] 리뷰가 필요한 사람(Reviewers)을 추가했나요?
- [ ] 이슈 책임자(Assignees)를 추가했나요?
- [ ] 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
  - [Feat]
  - [Docs]
  - [Chore]
  - [Refactor]
  - [Fix]
- [ ] Labels에는 해당 이슈의 성향을 잘 나타내나요?
- [ ] 해당 pull-request가 파트(front-end 또는 back-end)에 종속된다면 Labels에 파트를 표시했나요?
 -->
# Describe your changes
- bearer 문자열을 지우기 위해 substring(7) 을 사용하는데 여기에서 null 또는 비어있을 경우 빈 문자열로 반환하기 위한 예외처리가 필요하다. 그래서 함수로 따로 뺐다.
- 여기에서 꽤나 오래 걸렸는데 application.properties 파일에 jwt-secret 파일이 큰 따음표 두 개로 문자열 개수가 34가 되었기 때문이다. 이는 예외의 메시지를 직접 찍어보는 것으로 해결했다.

# Issue number and link
- #47
