### PR TITLE
feat: Read my board info encrypted id 및 theme 추가 구현

### DIFF
--- a/src/main/java/com/strcat/controller/UserController.java
+++ b/src/main/java/com/strcat/controller/UserController.java
@@ -1,0 +1,24 @@
+package com.strcat.controller;
+
+import com.strcat.dto.ReadMyBoardInfoResDto;
+import com.strcat.service.BoardService;
+import io.swagger.v3.oas.annotations.Parameter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final BoardService boardService;
+
+    @GetMapping("/boards")
+    public List<ReadMyBoardInfoResDto> readMyBoardInfo(
+            @Parameter(hidden = true) @RequestHeader("Authorization") String token) {
+        return boardService.readMyBoardInfo(token);
+    }
+}

--- a/src/main/java/com/strcat/dto/ReadMyBoardInfoResDto.java
+++ b/src/main/java/com/strcat/dto/ReadMyBoardInfoResDto.java
@@ -1,0 +1,12 @@
+package com.strcat.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ReadMyBoardInfoResDto {
+    private final String encryptedBoardId;
+    private final String title;
+    private final String theme;
+}

--- a/src/main/java/com/strcat/repository/BoardRepository.java
+++ b/src/main/java/com/strcat/repository/BoardRepository.java
@@ -1,9 +1,11 @@
 package com.strcat.repository;
 
 import com.strcat.domain.Board;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
+    List<Board> findByUserId(Long userId);
 }

--- a/src/main/java/com/strcat/service/BoardService.java
+++ b/src/main/java/com/strcat/service/BoardService.java
@@ -6,11 +6,14 @@ import com.strcat.domain.User;
 import com.strcat.dto.CreateBoardReqDto;
 import com.strcat.dto.ReadBoardResDto;
 import com.strcat.dto.ReadBoardSummaryResDto;
+import com.strcat.dto.ReadMyBoardInfoResDto;
 import com.strcat.exception.NotAcceptableException;
 import com.strcat.repository.BoardGroupRepository;
 import com.strcat.repository.BoardRepository;
 import com.strcat.util.AesSecretUtils;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +24,21 @@ public class BoardService {
     private final BoardGroupRepository boardGroupRepository;
     private final AesSecretUtils aesSecretUtils;
     private final UserService userService;
+
+    public List<Board> findByUserId(Long userId) {
+        return boardRepository.findByUserId(userId);
+    }
+
+    public List<ReadMyBoardInfoResDto> readMyBoardInfo(String token) {
+        User user = userService.getUser(token);
+        List<Board> boards = findByUserId(user.getId());
+        return boards.stream()
+                .map(board -> new ReadMyBoardInfoResDto(aesSecretUtils.encrypt(
+                        board.getId()),
+                        board.getTitle(),
+                        board.getTheme()))
+                .collect(Collectors.toList());
+    }
 
     public String createBoard(CreateBoardReqDto dto, String token) {
         Board board;


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Issue 생성 전 체크리스트(생성한 사람이 꼭 모두 체크해주세요!!)
- [ ] 이슈 이름은 다른 사람도 이해할 수 있나요?
- [ ] 리뷰가 필요한 사람(Reviewers)을 추가했나요?
- [ ] 이슈 책임자(Assignees)를 추가했나요?
- [ ] 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
  - [Feat]
  - [Docs]
  - [Chore]
  - [Refactor]
  - [Fix]
- [ ] Labels에는 해당 이슈의 성향을 잘 나타내나요?
- [ ] 해당 pull-request가 파트(front-end 또는 back-end)에 종속된다면 Labels에 파트를 표시했나요?
 -->
# Describe your changes
- 기존에 JPA projection으로 interface를 사용 했던 PR을 둔 상태로 테스트 위해 암호화 된 id를 제공하는 API 구현 완료 

# Issue number and link
- #93 
