### PR TITLE
refactor: 보드 정보, 보드 그룹 정보 조회 시 암호화를 직접하지 않고 엔티티 인스턴스에서 가져오도록 변경

### DIFF
--- a/src/main/java/com/strcat/service/BoardGroupService.java
+++ b/src/main/java/com/strcat/service/BoardGroupService.java
@@ -62,9 +62,8 @@ public class BoardGroupService {
         User user = userService.getUser(token);
         List<BoardGroup> boardGroups = boardGroupRepository.findByUserId(user.getId());
 
-        // 테스트를 위해 우선 바로 암호화 해서 보내주는 방식으로 구현함
         return boardGroups.stream()
-                .map(boardGroup -> new ReadMyInfoResDto(secureDataUtils.encrypt(boardGroup.getId()),
+                .map(boardGroup -> new ReadMyInfoResDto(boardGroup.getEncryptedId(),
                         boardGroup.getTitle()))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/strcat/service/BoardService.java
+++ b/src/main/java/com/strcat/service/BoardService.java
@@ -36,8 +36,7 @@ public class BoardService {
         User user = userService.getUser(token);
         List<Board> boards = findByUserId(user.getId());
         return boards.stream()
-                .map(board -> new ReadMyInfoResDto(secureDataUtils.encrypt(
-                        board.getId()),
+                .map(board -> new ReadMyInfoResDto(board.getEncryptedId(),
                         board.getTitle()))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
- 암호화 할 때 현재 시간에 의존하기 때문에 저장할 때 암호화를 한 뒤 읽을 때 또 암호화를 해서 넣는다면 같은 아이디라 해도 시간이 달라서 암호화 된 문자열이 달라진다.

<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Issue 생성 전 체크리스트(생성한 사람이 꼭 모두 체크해주세요!!)
- [ ] 이슈 이름은 다른 사람도 이해할 수 있나요?
- [ ] 리뷰가 필요한 사람(Reviewers)을 추가했나요?
- [ ] 이슈 책임자(Assignees)를 추가했나요?
- [ ] 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
  - [Feat]
  - [Docs]
  - [Chore]
  - [Refactor]
  - [Fix]
- [ ] Labels에는 해당 이슈의 성향을 잘 나타내나요?
- [ ] 해당 pull-request가 파트(front-end 또는 back-end)에 종속된다면 Labels에 파트를 표시했나요?
 -->
# Describe your changes
- 기존에 암호화 된 아이디를 db에 저장하지 않았을 시기에 남아있던 코드를 리팩터링 했다.

# Issue number and link
- #116 
