### PR TITLE
fix: 사진 저장 오류 수정

### DIFF
--- a/src/main/java/com/strcat/domain/Content.java
+++ b/src/main/java/com/strcat/domain/Content.java
@@ -36,7 +36,7 @@ public class Content {
     @Column(length = 1000, nullable = false)
     private String text;
 
-    @Column(length = 1000)
+    @Column(columnDefinition = "TEXT")
     private String photoUrl;
 
     @JsonIgnore

--- a/src/main/java/com/strcat/domain/Content.java
+++ b/src/main/java/com/strcat/domain/Content.java
@@ -36,7 +36,7 @@ public class Content {
     @Column(length = 1000, nullable = false)
     private String text;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(length = 500)
     private String photoUrl;
 
     @JsonIgnore

--- a/src/main/java/com/strcat/domain/Content.java
+++ b/src/main/java/com/strcat/domain/Content.java
@@ -36,7 +36,7 @@ public class Content {
     @Column(length = 1000, nullable = false)
     private String text;
 
-    @Column
+    @Column(length = 1000)
     private String photoUrl;
 
     @JsonIgnore

--- a/src/main/java/com/strcat/service/PictureService.java
+++ b/src/main/java/com/strcat/service/PictureService.java
@@ -13,15 +13,15 @@ public class PictureService {
 
     public boolean isInvalidContentType(String contentType) {
         return switch (contentType) {
-            case "image/jpeg", "image/png" -> false;
+            case "image/jpeg", "image/png", "image/jpg" -> false;
             default -> true;
         };
     }
 
     public String postPicture(String encryptedBoardId, MultipartFile picture) {
-//        if (isInvalidContentType(picture.getContentType())) {
-//            throw new NotAcceptableException("처리할 수 없는 파일 형식입니다.");
-//        }
+        if (isInvalidContentType(picture.getContentType())) {
+            throw new NotAcceptableException("처리할 수 없는 파일 형식입니다.");
+        }
 
         return pictureRepository.postPicture(encryptedBoardId, picture);
     }


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Issue 생성 전 체크리스트(생성한 사람이 꼭 모두 체크해주세요!!)
- [ ] 이슈 이름은 다른 사람도 이해할 수 있나요?
- [ ] 리뷰가 필요한 사람(Reviewers)을 추가했나요?
- [ ] 이슈 책임자(Assignees)를 추가했나요?
- [ ] 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
  - [Feat]
  - [Docs]
  - [Chore]
  - [Refactor]
  - [Fix]
- [ ] Labels에는 해당 이슈의 성향을 잘 나타내나요?
- [ ] 해당 pull-request가 파트(front-end 또는 back-end)에 종속된다면 Labels에 파트를 표시했나요?
 -->
# Describe your changes
- 기존에 주석처리 했던 데이터 타입 확인부분을 다시 되살림
- jpg타입도 허용 타입으로 추가함


- photo_url 프로퍼티의 길이가 지정되어 있지 않아 저장시 data too long 에러가 나고 있었음
  - 제목길이에 따라 photoUrl의 길이도 유동적이므로 TEXT 타입으로 설정함

# Issue number and link
- 
