### PR TITLE
feat: URL 단축 기능 구현 #137

### DIFF
--- a/src/main/java/com/strcat/controller/ShareController.java
+++ b/src/main/java/com/strcat/controller/ShareController.java
@@ -1,0 +1,24 @@
+package com.strcat.controller;
+
+import com.strcat.service.ShortUrlService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/share")
+@RequiredArgsConstructor
+public class ShareController {
+    private final ShortUrlService shortUrlService;
+
+    @GetMapping
+    @SecurityRequirement(name = "Bearer Authentication")
+    public String getShortUrl(
+            @RequestParam("url") String url
+    ) throws Exception {
+        return shortUrlService.generateUrl(url);
+    }
+}

--- a/src/main/java/com/strcat/service/ShortUrlService.java
+++ b/src/main/java/com/strcat/service/ShortUrlService.java
@@ -1,0 +1,61 @@
+package com.strcat.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class ShortUrlService {
+    private final String id;
+    private final String secret;
+
+    @Autowired
+    public ShortUrlService(@Value("${naver.client.id}") String id,
+                           @Value("${naver.client.secret}") String secret) {
+        this.id = id;
+        this.secret = secret;
+    }
+
+    public String generateUrl(String originUrl) throws Exception {
+        // 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Naver-Client-Id", id);
+        headers.set("X-Naver-Client-Secret", secret);
+
+        // 쿼리 파라미터 설정
+        String API_URL = "https://openapi.naver.com/v1/util/shorturl";
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(API_URL)
+                .queryParam("url", originUrl);
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        //header 설정
+        restTemplate.setInterceptors(List.of(
+                (HttpRequest request, byte[] body, ClientHttpRequestExecution execution) -> {
+                    request.getHeaders().addAll(headers);
+                    return execution.execute(request, body);
+                }
+        ));
+
+        String json = restTemplate.getForEntity(builder.toUriString(), String.class).getBody();
+
+        return extractUrl(json);
+    }
+
+    private String extractUrl(String rawResponse) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        JsonNode jsonNode = objectMapper.readTree(rawResponse).get("result");
+
+        return jsonNode.get("url").asText();
+    }
+}


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Issue 생성 전 체크리스트(생성한 사람이 꼭 모두 체크해주세요!!)
- [ ] 이슈 이름은 다른 사람도 이해할 수 있나요?
- [ ] 리뷰가 필요한 사람(Reviewers)을 추가했나요?
- [ ] 이슈 책임자(Assignees)를 추가했나요?
- [ ] 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
  - [Feat]
  - [Docs]
  - [Chore]
  - [Refactor]
  - [Fix]
- [ ] Labels에는 해당 이슈의 성향을 잘 나타내나요?
- [ ] 해당 pull-request가 파트(front-end 또는 back-end)에 종속된다면 Labels에 파트를 표시했나요?
 -->
# Describe your changes
- 암호화 된 URL이 너무 길어서 유저가 사용하기 힘들 것 같다는 의견이 생겼다. 때문에 이를 줄일 수 있는 방식을 찾아봤다.
- [Naver developers](https://developers.naver.com/docs/utils/shortenurl/)에서 제공하는 기능으로 일종의 DNS 서버를 중간에 두는 방식으로 해결하려 한다.
- 프론트의 요청이 서버에 들어오면 URL을 암호화 한 뒤 Naver에 API를 요청한다. 다음 길이가 줄어든 URL을 서버에서 받고, 해당 URL을 응답으로 프론트에게 보낸다.
- Naver에서는 줄어든 URL과 줄어들기 전의 URL을 저장하여 저장 수가 아닌 요청 수대로 요금이 부과된다. 하루에 20,000 건 요청이 무료이다.


# Issue number and link
- #137 
