### PR TITLE
fix, refactor: 불필요한 쿼리가 중복으로 호출되는 문제 해결

### DIFF
--- a/src/main/java/com/strcat/config/SecurityConfig.java
+++ b/src/main/java/com/strcat/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.strcat.config.oauth.JwtAuthFilter;
 import com.strcat.config.oauth.JwtAuthenticationEntryPoint;
 import com.strcat.config.oauth.OAuthFailureHandler;
 import com.strcat.config.oauth.OAuthSuccessHandler;
+import com.strcat.service.UserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -24,7 +25,7 @@ public class SecurityConfig {
     private final OAuthSuccessHandler oAuthSuccessHandler;
     private final OAuthFailureHandler oAuthFailureHandler;
     private final WebConfig webConfig;
-    private final JwtAuthFilter jwtAuthFilter;
+    private final UserService userService;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
 
@@ -40,18 +41,17 @@ public class SecurityConfig {
             "boards/*/summaries",
             "boards/*/contents",
             "boards/*/contents/pictures",
-            "board-groups/*"
     };
 
     @Autowired
     public SecurityConfig(OAuthSuccessHandler oAuthSuccessHandler,
                           OAuthFailureHandler oAuthFailureHandler, WebConfig webConfig,
-                          JwtAuthFilter jwtAuthFilter,
+                          UserService userService,
                           JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint) {
         this.oAuthSuccessHandler = oAuthSuccessHandler;
         this.oAuthFailureHandler = oAuthFailureHandler;
         this.webConfig = webConfig;
-        this.jwtAuthFilter = jwtAuthFilter;
+        this.userService = userService;
         this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
     }
 
@@ -71,7 +71,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
                 .addFilter(webConfig.corsFilter())
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthFilter(userService), UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling((httpSecurityExceptionHandlingConfigurer) -> httpSecurityExceptionHandlingConfigurer
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 );

--- a/src/main/java/com/strcat/service/UserService.java
+++ b/src/main/java/com/strcat/service/UserService.java
@@ -34,4 +34,16 @@ public class UserService {
         Optional<User> user = userRepository.findById(userId);
         return user.isPresent();
     }
+
+    public Optional<User> validate(String rawToken) {
+        String token = jwtUtils.exportToken(rawToken);
+
+        if (jwtUtils.isValidateToken(token)) {
+            Long userId = jwtUtils.parseUserId(token);
+
+            return userRepository.findById(userId);
+        }
+
+        return Optional.empty();
+    }
 }

--- a/src/main/java/com/strcat/util/JwtUtils.java
+++ b/src/main/java/com/strcat/util/JwtUtils.java
@@ -3,7 +3,6 @@ package com.strcat.util;
 import com.strcat.exception.NotAcceptableException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import jakarta.servlet.http.HttpServletRequest;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Date;
@@ -31,9 +30,7 @@ public class JwtUtils {
         this.secretKey = Keys.hmacShaKeyFor(encoded);
     }
 
-    public String exportToken(HttpServletRequest request) {
-        String rawToken = request.getHeader("Authorization");
-
+    public String exportToken(String rawToken) {
         if (rawToken == null
                 || rawToken.isBlank()
                 || rawToken.length() < 6) {
@@ -61,10 +58,6 @@ public class JwtUtils {
     }
 
     public boolean isValidateToken(String token) {
-        if (token == null || token.isBlank()) {
-            return false;
-        }
-
         try {
             return Jwts.parser()
                     .verifyWith(secretKey)


### PR DESCRIPTION
JwtAuthFilter가GenericFilterBean을 사용하는데 @Component 어노테이션이 붙어있어서 자동으로 SpringBoot에서 JwtAuthFilter를 Filter로 등록하는데, 중복으로 addFilterBefore를 사용하여 Filter로 등록하여 2번 등록되는 문제가 있었다.

이를 해결하기위해 @Component 어노테이션을 제거했다.

그리고, 인증로직이 복잡하게 작성되어있는 부분을 리팩터링 하였다.

<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Issue 생성 전 체크리스트(생성한 사람이 꼭 모두 체크해주세요!!)
- [ ] 이슈 이름은 다른 사람도 이해할 수 있나요?
- [ ] 리뷰가 필요한 사람(Reviewers)을 추가했나요?
- [ ] 이슈 책임자(Assignees)를 추가했나요?
- [ ] 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
  - [Feat]
  - [Docs]
  - [Chore]
  - [Refactor]
  - [Fix]
- [ ] Labels에는 해당 이슈의 성향을 잘 나타내나요?
- [ ] 해당 pull-request가 파트(front-end 또는 back-end)에 종속된다면 Labels에 파트를 표시했나요?
 -->
# Describe your changes
- 불필요한 쿼리가 중복으로 호출되는 문제 해결
- 인증로직 관련 리팩터링

# Issue number and link
- #172 
