### PR TITLE
fix: userId가 null일때 에러가 발생하던 부분 수정

### DIFF
--- a/src/main/java/com/strcat/config/SecurityConfig.java
+++ b/src/main/java/com/strcat/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
             "favicon.ico",
             "v3/api-docs/**",
             "swagger-ui/**",
-            "boards/*",
+            "boards/{boardId}",
             "boards/*/summaries",
             "boards/*/contents",
             "boards/*/contents/pictures",

--- a/src/main/java/com/strcat/controller/BoardController.java
+++ b/src/main/java/com/strcat/controller/BoardController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.security.core.Authentication;
@@ -84,7 +85,8 @@ public class BoardController {
     @Operation(summary = "보드 조회", description = "보드에 대한 모든 정보와 보드 소유자 여부를 반환합니다.")
     public ReadBoardResDto readBoard(Authentication authentication,
                                      @PathVariable(name = "boardId") String encryptedBoardId) {
-        Long userId = (Long) authentication.getPrincipal();
+        Long userId = authentication != null ? (Long) authentication.getPrincipal() : null;
+
         return boardService.readBoard(encryptedBoardId, userId);
     }
 
@@ -101,7 +103,9 @@ public class BoardController {
             @Content(examples = {@ExampleObject("인증 실패")})})
     public ReadBoardResDto deleteContents(@PathVariable(name = "boardId") String encryptedBoardId, @RequestBody
             DeleteContentReqDto dto, Authentication authentication) {
-        if (authentication == null) throw new ResponseStatusException(HttpStatusCode.valueOf(401));
+        if (authentication == null) {
+            throw new ResponseStatusException(HttpStatusCode.valueOf(401));
+        }
 
         User user = (User) authentication.getCredentials();
 

--- a/src/main/java/com/strcat/service/BoardService.java
+++ b/src/main/java/com/strcat/service/BoardService.java
@@ -39,15 +39,14 @@ public class BoardService {
     public ReadBoardResDto readBoard(String encryptedBoardId, Long userId) {
         Board board = boardRepository.findByEncryptedId(encryptedBoardId)
                 .orElseThrow(() -> new NotAcceptableException("존재하지 않는 보드입니다."));
-
-        try {
+        if (userId != null) {
             recordHistoryUseCase.write(userId,
                     List.of(new HistoryItem(encryptedBoardId, board.getTitle(), LocalDateTime.now())));
+
             Boolean isOwner = userId.equals(board.getUser().getId());
             return board.toReadBoardResDto(isOwner);
-        } catch (NotAcceptableException e) {
-            return board.toReadBoardResDto(false);
         }
+        return board.toReadBoardResDto(false);
     }
 
     public ReadBoardSummaryResDto readSummary(String encryptedBoardId) {


### PR DESCRIPTION
userId가 null일 때, 에러가 발생하여 비로그인 상태에서
보드 조회가 실패하던 부분 수정.

<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Issue 생성 전 체크리스트(생성한 사람이 꼭 모두 체크해주세요!!)
- [ ] 이슈 이름은 다른 사람도 이해할 수 있나요?
- [ ] 리뷰가 필요한 사람(Reviewers)을 추가했나요?
- [ ] 이슈 책임자(Assignees)를 추가했나요?
- [ ] 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
  - [Feat]
  - [Docs]
  - [Chore]
  - [Refactor]
  - [Fix]
- [ ] Labels에는 해당 이슈의 성향을 잘 나타내나요?
- [ ] 해당 pull-request가 파트(front-end 또는 back-end)에 종속된다면 Labels에 파트를 표시했나요?
 -->
# Describe your changes
- fix: userId가 null일때 에러가 발생하던 부분 수정

# Issue number and link
- 
